### PR TITLE
Fix a bug in the mesh mask

### DIFF
--- a/aux_matlab/MeshOperations/MeshMask.m
+++ b/aux_matlab/MeshOperations/MeshMask.m
@@ -36,7 +36,7 @@ function maskedMesh = MeshMask(mesh,mask)
     maskedMesh.idx.mi = edges;
     
     %% Update filter
-    if mesh.alpga_filter=='none'
+    if mesh.alpha_filter=='none'
         %no filtering
         filter    = @(x) x;
         filter_ct = @(x) x;        


### PR DESCRIPTION
Fix the typo bug related to the mesh mask, will lead to the breakdown when running cavity test case.